### PR TITLE
Add GitLab mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -1,0 +1,23 @@
+name: Mirror to GitLab
+on:
+  push:
+    branches: [main]
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push to GitLab
+        run: |
+          if [ "${{ github.repository_owner }}" = "duanegoodner" ]; then
+            GITLAB_NS="duane.goodner"
+          else
+            GITLAB_NS="${{ github.repository_owner }}"
+          fi
+          REPO_NAME="${{ github.event.repository.name }}"
+          git push --force \
+            "https://oauth2:${GITLAB_TOKEN}@gitlab.com/${GITLAB_NS}/${REPO_NAME}.git" main
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Action that mirrors the main branch to GitLab on every push.